### PR TITLE
handling missing elevation as a unified 0

### DIFF
--- a/biome4driver.f90
+++ b/biome4driver.f90
@@ -162,15 +162,19 @@ allocate(cldp(cntx,cnty,tlen))
 !-------------------------------------------------------
 ! elevation
 
-status = nf90_inq_varid(ncid,'elv',varid)
+print *, 'Inquiring elevation variable'
+status = nf90_inq_varid(ncid, 'elv', varid)
 if (status == nf90_noerr) then
 
-  status = nf90_get_var(ncid,varid,elv,start=[srtx,srty],count=[cntx,cnty])
+  print *, 'Reading elevation variable'
+  status = nf90_get_var(ncid, varid, elv, start=[srtx, srty,1], count=[cntx, cnty])
   if (status /= nf90_noerr) call handle_err(status)
-  
+  print *, 'Read elevation variable'
+
 else
 
   elv = 0.
+  print *, 'Elevation variable not found, set to 0'
 
 end if
 


### PR DESCRIPTION
## Purpose 

Instead of outputting an error and blocking the process when elevation is missing, replace all elevation fields as 0.

## Code changes:

- `biome4driver.f90`: adding an if else statement to set the elv as 0 uniformly and outputting an information message in the standard output. 

## Review

For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)